### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 這是一個基於 Model Context Protocol 的伺服器工具集，提供多種功能來輔助開發和維護工作。
 
+<a href="https://glama.ai/mcp/servers/@GonTwVn/GonMCPtool">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GonTwVn/GonMCPtool/badge" alt="GonMCPtool MCP server" />
+</a>
+
 ## 功能概覽
 
 ### 基本工具
@@ -190,4 +194,4 @@ fileRead({
 
 3. 檔案路徑可以是相對路徑或絕對路徑。
 
-4. 進行批次操作時，建議使用 `edit_file` 工具，可以在一次調用中進行多個編輯操作.
+4. 進行批次操作時，建議使用 `edit_file` 工具，可以在一次調用中進行多個編輯操作。


### PR DESCRIPTION
This PR adds a badge for the [GonMCPtool](https://glama.ai/mcp/servers/@GonTwVn/GonMCPtool) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@GonTwVn/GonMCPtool">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GonTwVn/GonMCPtool/badge" alt="GonMCPtool MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.